### PR TITLE
fix(docker): resolve permission denied error in distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 ARG TARGETARCH
 
-COPY bin/argocd-proxy-api-linux-${TARGETARCH} /bin/argocd-proxy-api
+COPY bin/argocd-proxy-api-linux-${TARGETARCH} /app/argocd-proxy-api
 
 EXPOSE 5001
-ENTRYPOINT ["/bin/argocd-proxy-api"]
+ENTRYPOINT ["/app/argocd-proxy-api"]


### PR DESCRIPTION
- Moved binary from /bin to /app to ensure compatibility with non-root user in distroless:nonroot
- Ensured binary is executable and statically linked with CGO_ENABLED=0
- Updated Dockerfile ENTRYPOINT path accordingly
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix permission denied error in distroless Docker image by relocating the application binary to a non-restricted directory.
Main changes:
- Moved binary from `/bin/argocd-proxy-api` to `/app/argocd-proxy-api` to address permission restrictions
- Updated ENTRYPOINT to reference the new binary location

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
