### PR TITLE
fix: add executable permissions to binary in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 ARG TARGETARCH
 
-COPY bin/argocd-proxy-api-linux-${TARGETARCH} /app/argocd-proxy-api
+COPY --chmod=755 bin/argocd-proxy-api-linux-${TARGETARCH} /app/argocd-proxy-api
 
 EXPOSE 5001
 ENTRYPOINT ["/app/argocd-proxy-api"]


### PR DESCRIPTION
- Add --chmod=755 flag to COPY command in Dockerfile to ensure binary has execute permissions
- Fixes 'permission denied' error when running container with distroless base image
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix Docker build process by adding executable permissions to the argocd-proxy-api binary during image creation.
Main changes:
- Added --chmod=755 flag to COPY command in Dockerfile to ensure binary has proper execution permissions

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
