### PR TITLE
feat: add in-memory TTL cache for ArgoCD API responses

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,68 @@
+package cache
+
+import (
+	"sync"
+	"time"
+)
+
+// Cache is a generic thread-safe in-memory cache with TTL expiration.
+type Cache[T any] struct {
+	mu        sync.RWMutex
+	value     T
+	cachedAt  time.Time
+	ttl       time.Duration
+	populated bool
+}
+
+// New creates a new Cache with the given TTL. A TTL of 0 disables caching.
+func New[T any](ttl time.Duration) *Cache[T] {
+	return &Cache[T]{ttl: ttl}
+}
+
+// Get returns the cached value and true if it exists and has not expired.
+// Returns the zero value and false otherwise.
+func (c *Cache[T]) Get() (T, bool) {
+	if c.ttl <= 0 {
+		var zero T
+		return zero, false
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if !c.populated {
+		var zero T
+		return zero, false
+	}
+
+	if time.Since(c.cachedAt) > c.ttl {
+		var zero T
+		return zero, false
+	}
+
+	return c.value, true
+}
+
+// Set stores a value in the cache with the current timestamp.
+func (c *Cache[T]) Set(value T) {
+	if c.ttl <= 0 {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.value = value
+	c.cachedAt = time.Now()
+	c.populated = true
+}
+
+// Invalidate clears the cached value.
+func (c *Cache[T]) Invalidate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var zero T
+	c.value = zero
+	c.populated = false
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,123 @@
+package cache
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestGetOnEmptyCache(t *testing.T) {
+	c := New[string](30 * time.Second)
+
+	val, ok := c.Get()
+	if ok {
+		t.Error("expected cache miss on empty cache")
+	}
+	if val != "" {
+		t.Errorf("expected zero value, got %q", val)
+	}
+}
+
+func TestSetAndGet(t *testing.T) {
+	c := New[string](30 * time.Second)
+
+	c.Set("hello")
+
+	val, ok := c.Get()
+	if !ok {
+		t.Error("expected cache hit after Set")
+	}
+	if val != "hello" {
+		t.Errorf("expected %q, got %q", "hello", val)
+	}
+}
+
+func TestExpiry(t *testing.T) {
+	c := New[int](50 * time.Millisecond)
+
+	c.Set(42)
+
+	val, ok := c.Get()
+	if !ok || val != 42 {
+		t.Fatalf("expected hit with value 42, got ok=%v val=%v", ok, val)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	_, ok = c.Get()
+	if ok {
+		t.Error("expected cache miss after TTL expiry")
+	}
+}
+
+func TestInvalidate(t *testing.T) {
+	c := New[string](30 * time.Second)
+
+	c.Set("data")
+	c.Invalidate()
+
+	_, ok := c.Get()
+	if ok {
+		t.Error("expected cache miss after Invalidate")
+	}
+}
+
+func TestZeroTTLDisablesCaching(t *testing.T) {
+	c := New[string](0)
+
+	c.Set("should not cache")
+
+	_, ok := c.Get()
+	if ok {
+		t.Error("expected cache miss when TTL is 0")
+	}
+}
+
+func TestOverwrite(t *testing.T) {
+	c := New[int](30 * time.Second)
+
+	c.Set(1)
+	c.Set(2)
+
+	val, ok := c.Get()
+	if !ok || val != 2 {
+		t.Errorf("expected 2, got ok=%v val=%v", ok, val)
+	}
+}
+
+func TestSliceCache(t *testing.T) {
+	c := New[[]string](30 * time.Second)
+
+	c.Set([]string{"a", "b", "c"})
+
+	val, ok := c.Get()
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if len(val) != 3 || val[0] != "a" || val[2] != "c" {
+		t.Errorf("unexpected cached slice: %v", val)
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	c := New[int](30 * time.Second)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func(v int) {
+			defer wg.Done()
+			c.Set(v)
+		}(i)
+		go func() {
+			defer wg.Done()
+			c.Get()
+		}()
+	}
+	wg.Wait()
+
+	_, ok := c.Get()
+	if !ok {
+		t.Error("expected cache to have a value after concurrent writes")
+	}
+}

--- a/config/project_groups.go
+++ b/config/project_groups.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
 
 // ProjectGroup represents a group of projects with metadata
@@ -28,6 +29,7 @@ type Config struct {
 	ArgocdPassword  string
 	ProjectGroups   []ProjectGroup
 	IgnoredProjects []string
+	CacheTTL        time.Duration
 }
 
 // LoadConfig loads configuration from environment variables
@@ -56,6 +58,14 @@ func LoadConfig() (*Config, error) {
 			return nil, fmt.Errorf("failed to parse PROJECT_GROUPS: %w", err)
 		}
 	}
+
+	// Load cache TTL from environment variable (default: 30s)
+	cacheTTLStr := getEnvOrDefault("CACHE_TTL", "30s")
+	cacheTTL, err := time.ParseDuration(cacheTTLStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CACHE_TTL %q: %w", cacheTTLStr, err)
+	}
+	config.CacheTTL = cacheTTL
 
 	// Load ignored projects from environment variable
 	if ignoredProjectsStr := os.Getenv("IGNORED_PROJECTS"); ignoredProjectsStr != "" {

--- a/env.example
+++ b/env.example
@@ -22,5 +22,10 @@ PROJECT_GROUPS=[]
 # Example: IGNORED_PROJECTS=test-*,*-dev,ignore-me,*temp*
 IGNORED_PROJECTS=
 
+# Cache TTL for ArgoCD API responses (Go duration format, default: 30s)
+# Set to "0s" to disable caching
+# Examples: "30s", "1m", "5m"
+# CACHE_TTL=30s
+
 # Optional: Gin Framework Mode (development, test, release)
 # GIN_MODE=release 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -76,6 +76,25 @@ var (
 	)
 )
 
+// Cache metrics
+var (
+	CacheHitsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cache_hits_total",
+			Help: "Total number of cache hits.",
+		},
+		[]string{"cache"},
+	)
+
+	CacheMissesTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "cache_misses_total",
+			Help: "Total number of cache misses.",
+		},
+		[]string{"cache"},
+	)
+)
+
 // Build info metric
 var BuildInfo = promauto.NewGaugeVec(
 	prometheus.GaugeOpts{


### PR DESCRIPTION
- Add generic Cache[T] package with thread-safe get/set/invalidate and TTL expiry
- Cache GetProjects and GetApplications responses (all derived endpoints benefit)
- Add CACHE_TTL env variable (Go duration format, default 30s, 0s to disable)
- Add cache_hits_total and cache_misses_total Prometheus counters
- Add tests for cache package, config parsing, and service caching behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced caching mechanism for improved performance, with configurable time-to-live (TTL) via environment variable.
  * Added cache metrics tracking hits and misses.
  * Enabled caching for project and application data queries.

* **Configuration**
  * New CACHE_TTL environment variable (default 30 seconds); set to 0 to disable caching.

* **Tests**
  * Added comprehensive caching behavior tests including TTL expiration, concurrency, and metrics validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add thread-safe in-memory TTL cache to reduce ArgoCD API load and improve response times for projects and applications endpoints.

Main changes:
- Implemented generic Cache[T] package with TTL expiration, thread-safe operations using RWMutex, and configurable duration via CACHE_TTL environment variable
- Integrated caching in ArgocdService for GetProjects and GetApplications methods with cache hit/miss metrics tracking
- Added comprehensive test coverage for cache operations including concurrency, expiry, and zero-TTL disable behavior

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
